### PR TITLE
consider 'log' progression for scale-y

### DIFF
--- a/zingchart.jquery.js
+++ b/zingchart.jquery.js
@@ -1489,15 +1489,17 @@
 					y = node;
 				}
 
-				if (logScale) {
-					y = log(y);
+				if (typeof x === "number" && isFinite(x) && typeof y === "number" && isFinite(y)) {
+					if (logScale) {
+						y = log(y);
+					}
+	
+					sxy += x*y;
+					sx += x;
+					sy += y;
+					sx2 += x*x;
+					l++;
 				}
-
-				sxy += x*y;
-				sx += x;
-				sy += y;
-				sx2 += x*x;
-				l++;
 			}
 
 			var b = (l * sxy - sx * sy) / (l * sx2 - sx * sx);


### PR DESCRIPTION
When computing linear regressions on logarithmic scales, log function should be applied to y values and the resulting range compensated accordingly.

The scatter example shown at http://www.zingchart.com/blog/2016/01/06/scatter-plot-examples/ is clearly not well represented by the trend line.

The proposed changes were tested with this fiddle: http://jsfiddle.net/yuu9hsyn/2/ (see lines 1459-1543)
and the result shows the computed trend line is now correct:

![logaritmictrendline](https://cloud.githubusercontent.com/assets/6148980/12580519/95ab41d8-c430-11e5-94ba-ffbbe0eb5526.png)

As a side note, it seems `progression: "log"` is mapped to the `Math.log` function hence computing the **natural logarithm** of y values: in my humble opinion, `Math.log10` would be a more appropriate choice since scientific plots usually make use of the base 10 logarithm in place of the natural one.
In case you'll ever decide to switch to `Math.log10` make sure to modify the proposed changes to use `Math.pow(10, x)` in place of `Math.exp` to compensate the computed range result.
